### PR TITLE
cleanup: remove unused child process list wiring

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -116,11 +116,6 @@ struct thread {
 
 	// auto-increment를 저장하기 위한 next_fd 
 	int next_fd; 
-
-	// child process list를 추적하기 위한 thread list 
-	struct list child_process_list; 
-
-	struct list_elem child_process_elem; 
 	
 	// donation 리스트 등록 상태 추적 플래그(in_donation_list)를 둔다.
 	bool in_donation_list;

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -246,9 +246,6 @@ thread_create (const char *name, int priority,
 	init_thread (t, name, priority);
 	tid = t->tid = allocate_tid ();
 
-	struct thread *curr_process = thread_current(); 
-	list_push_back(&curr_process->child_process_list, &t->child_process_elem);
-	
 	/* Call the kernel_thread if it scheduled.
 	 * Note) rdi is 1st argument, and rsi is 2nd argument. */
 	t->tf.rip = (uintptr_t) kernel_thread;
@@ -498,7 +495,6 @@ init_thread (struct thread *t, const char *name, int priority) {
 	for (int i = 0; i < ARG_MAX; i++) {
 		t->fd_table[i] = NULL; 
 	}
-	list_init(&t->child_process_list); 	
 	list_init(&t->donation_candidates); // donation 리스트를 초기화한다.
 	// in_donation_list를 false로 초기화한다.
 	t->in_donation_list = false;


### PR DESCRIPTION
## Summary
- remove unused `child_process_list` and `child_process_elem` fields from `struct thread`
- remove dead list initialization in `init_thread()`
- remove unused child list insertion in `thread_create()`

## Test plan
- [x] `git diff` reviewed for only intended cleanup scope
- [ ] run thread/userprog regression tests as needed

Made with [Cursor](https://cursor.com)